### PR TITLE
Move Azure region to apiKeys.js

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -1,0 +1,16 @@
+# Azure Keys
+
+Azure service keys are stored in `apiKeys.js`.
+
+
+Example `apiKeys.js`
+```javascript
+const AZURE_KEYS = {
+    key: [
+        'totally_the_first_azure_key',
+        'totally_the_second_azure_key'
+    ],
+    region: 'azureregion'
+};
+
+```

--- a/js/facelock.js
+++ b/js/facelock.js
@@ -4,7 +4,7 @@
 /**
  * @type {FaceJS}
  */
-const FACEJS = new FaceJS(AZURE_KEYS.key1, 'westcentralus');
+const FACEJS = new FaceJS(AZURE_KEYS.key[0], AZURE_KEYS.region);
 
 /**
  * The face id of the calibrated face. Null if no face has been calibrated.

--- a/js/facelock.js
+++ b/js/facelock.js
@@ -4,7 +4,7 @@
 /**
  * @type {FaceJS}
  */
-const FACEJS = new FaceJS(AZURE_KEYS.key[0], AZURE_KEYS.region);
+const FACEJS = new FaceJS(AZURE_KEYS.keys[0], AZURE_KEYS.region);
 
 /**
  * The face id of the calibrated face. Null if no face has been calibrated.


### PR DESCRIPTION
Move the azure region from being a magic string into the `apiKeys.js`. Also adds documentation for the format of `apiKeys.js`.

Closes #17 